### PR TITLE
Add configurable L2 decay parameter to SVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # smv
+
+Implementación sencilla de un SVM lineal multiclase entrenado con SGD.
+
+## Parámetros principales
+
+- `lr`: tasa de aprendizaje del optimizador.
+- `n_iter`: número de épocas completas sobre los datos.
+- `C`: peso del término hinge de la pérdida.
+- `avg`: activa el promedio de pesos (Averaged SGD).
+- `l2`: factor de regularización L2 aplicado como weight decay (`1.0` por defecto). Valores menores reducen la contracción de los pesos, lo que puede ser útil si se necesitan coeficientes más grandes.
+
+## Uso rápido
+
+```python
+from ml_svm import SVM
+
+model = SVM(lr=0.001, n_iter=200, C=1.0, avg=True, l2=0.5)
+model.fit(X_train, y_train)
+y_pred = model.predict(X_test)
+```
+
+Ajusta `l2` para equilibrar la regularización: un valor más bajo mantiene pesos de mayor magnitud, mientras que valores altos fomentan coeficientes pequeños.

--- a/ml_svm.py
+++ b/ml_svm.py
@@ -4,14 +4,16 @@ class SVM:
     """
     SVM lineal soft-margin OVR con SGD + weight decay + promedio de pesos (Averaged SGD).
     - C controla el castigo por violar el margen.
+    - l2 escala la fuerza del weight decay.
     - Usa datos estandarizados.
     Métodos: fit, predict.
     """
-    def __init__(self, lr=0.002, n_iter=150, C=1.0, avg=True):
+    def __init__(self, lr=0.002, n_iter=150, C=1.0, avg=True, l2=1.0):
         self.lr = lr
         self.n_iter = n_iter
         self.C = C
         self.avg = avg
+        self.l2 = l2
         self.W = None   # (k, d)
         self.b = None   # (k,)
         self.classes = None
@@ -40,7 +42,7 @@ class SVM:
                     margin = y_bin * (W[ci] @ xi + b[ci])
 
                     # weight decay (L2) SIEMPRE sobre W
-                    W[ci] *= (1.0 - self.lr)
+                    W[ci] *= (1.0 - self.lr * self.l2)
 
                     if margin < 1.0:
                         # gradiente de la parte hinge

--- a/tests/test_svm.py
+++ b/tests/test_svm.py
@@ -1,0 +1,18 @@
+import pathlib
+import sys
+
+import numpy as np
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from ml_svm import SVM
+
+
+def test_l2_parameter_scales_weight_decay():
+    X = np.array([[1.0]])
+    y = np.array([1])
+
+    model = SVM(lr=0.1, n_iter=2, C=1.0, avg=False, l2=0.5)
+    model.fit(X, y)
+
+    assert np.isclose(model.W[0, 0], 0.195, atol=1e-6)


### PR DESCRIPTION
## Summary
- add an `l2` hyperparameter to the SVM to scale the weight decay term
- update the README to document how to tune the new regularization strength
- add a regression test ensuring the `l2` factor alters the weight update as expected

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf4c8c3824832dac84d61c33b1a1c8